### PR TITLE
[T2624]: Fixed SONiC compilation on the "imt-bf-sde-9.0.0 branch.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -201,7 +201,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT rm /tmp/docker.gpg
 sudo LANG=C chroot $FILESYSTEM_ROOT add-apt-repository \
                                     "deb [arch=$CONFIGURED_ARCH] https://download.docker.com/linux/debian stretch stable"
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get update
-sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSION}
+sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION}
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y remove software-properties-common gnupg2
 
 ## Add docker config drop-in to select aufs, otherwise it may select other storage driver

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -292,7 +292,7 @@ RUN apt-get -t stretch-backports install -y debhelper
 RUN apt-get -y build-dep linux
 
 # For gobgp and telemetry build
-RUN export VERSION=1.11.5 \
+RUN export VERSION=1.14.2 \
 {%- if CONFIGURED_ARCH == "armhf" %}
  && wget https://storage.googleapis.com/golang/go$VERSION.linux-armv6l.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-armv6l.tar.gz \


### PR DESCRIPTION
[T2624]: Fixed SONiC compilation on the "imt-bf-sde-9.0.0 branch:
         * Install same version for docker-ce and docker-ce-cli in Baseimage
         * Update golang version for 1.11.5 to 1.14.2

#### Compilation errors:
```
Output of docker info:

Client:
Debug Mode: false

Server:
ERROR: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
errors pretty printing info
```