### PR TITLE
[T2624]: Use IMT copy of sonic-swss repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,8 @@
 	branch = imt-bf-sde-9.0.0
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/Azure/sonic-swss
+	url = https://github.com/InterfaceMasters/sonic-swss.git
+	branch = imt-bf-sde-9.0.0
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm


### PR DESCRIPTION
* Use  IMT copy of sonic-swss repository.
* Checkout to commit: [im-t2624]: Include sai headers (https://github.com/InterfaceMasters/sonic-swss/pull/1).
```
$ git submodule update --init --recursive
. . .
Submodule 'sonic-sairedis' (https://github.com/InterfaceMasters/sonic-sairedis.git) registered for path 'src/sonic-sairedis'
Submodule 'src/sonic-snmpagent' (https://github.com/Azure/sonic-snmpagent) registered for path 'src/sonic-snmpagent'
Submodule 'sonic-swss' (https://github.com/InterfaceMasters/sonic-swss.git) registered for path 'src/sonic-swss'
. . .
```
@vitalivanov @AndriiKit @oleksandrivantsiv